### PR TITLE
本番環境の設定

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,21 +5,24 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: mysql2
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: db/development.mysql2
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: db/test.mysql2
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: db/production.mysql2
+  username: root
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql.sock


### PR DESCRIPTION
# WHAT 
・AWSの設定（ポート３０００を開放）
・database.ymlのDBをsqliteからmysql2に書き換え
・database.ymlのproductionの設定に追記

# WHY
・本番環境を設定のため